### PR TITLE
Added bytes support + guard against failing parsing

### DIFF
--- a/app/components/Editor/Editor.tsx
+++ b/app/components/Editor/Editor.tsx
@@ -105,8 +105,15 @@ const Editor: React.FC<EditorProps> = ({ service, methodName, initialRequest, on
 
   useEffect(() => {
     if (service && methodName && !initialRequest) {
-      const { plain } = service.methodsMocks[methodName]();
-      dispatch(setData(JSON.stringify(plain, null, 2)));
+      try {
+        const { plain } = service.methodsMocks[methodName]();
+        dispatch(setData(JSON.stringify(plain, null, 2)));
+      } catch(e) {
+        console.error(e);
+        dispatch(setData(JSON.stringify({
+          "error": "Error parsing the request message, please report the problem sharing the offending protofile"
+        }, null, 2)));
+      }
     }
 
     if (initialRequest) {

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "css-loader": "^0.28.4",
     "css-modules-require-hook": "^4.0.6",
     "devtron": "^1.4.0",
-    "electron": "1.8.4",
+    "electron": "1.8.8",
     "electron-builder": "^19.8.0",
     "electron-builder-http": "^19.15.0",
     "electron-devtools-installer": "^2.0.1",
@@ -158,7 +158,7 @@
   "dependencies": {
     "@grpc/proto-loader": "^0.3.0",
     "antd": "^3.10.8",
-    "bloomrpc-mock": "^0.1.1",
+    "bloomrpc-mock": "^0.1.2",
     "electron-debug": "^1.1.0",
     "electron-store": "^2.0.0",
     "grpc": "^1.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -934,9 +934,10 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bloomrpc-mock@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/bloomrpc-mock/-/bloomrpc-mock-0.1.1.tgz#21bac8a2186f49bc7b1353ab8b08ff3f0984d822"
+bloomrpc-mock@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/bloomrpc-mock/-/bloomrpc-mock-0.1.2.tgz#1851a93a0b6a29d43e6aed2b0a0972833eea1441"
+  integrity sha512-ujMd8vQXvRrK+/GQZT7FDwA/MLeXZXILaEEOOk2q/+2VgbY6/oTxbHDskAGr59zMaPnP1zv0S/hxYguPLQuhsQ==
   dependencies:
     "@grpc/proto-loader" "^0.3.0"
     "@oclif/command" "^1"
@@ -2502,9 +2503,10 @@ electron-to-chromium@^1.2.7:
   version "1.3.84"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.84.tgz#2e55df59e818f150a9f61b53471ebf4f0feecc65"
 
-electron@1.8.4:
-  version "1.8.4"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.4.tgz#cca8d0e6889f238f55b414ad224f03e03b226a38"
+electron@1.8.8:
+  version "1.8.8"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.8.tgz#a90cddb075291f49576993e6f5c8bb4439301cae"
+  integrity sha512-1f9zJehcTTGjrkb06o6ds+gsRq6SYhZJyxOk6zIWjRH8hVy03y/RzUDELzNas71f5vcvXmfGVvyjeEsadDI8tg==
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^3.0.1"


### PR DESCRIPTION
Fixes https://github.com/uw-labs/bloomrpc/issues/2

- Updated `bloomrpc-mock` to contain the byte support fix
- Guard against failing message parsing
- Minor upgrade of Electron