### PR TITLE
Fixed nested namespace and map data-type parsing 

### DIFF
--- a/app/components/Editor/Request.tsx
+++ b/app/components/Editor/Request.tsx
@@ -30,7 +30,7 @@ export function Request({onChangeData, data, streamData}: RequestProps) {
             fontSize={13}
             cursorStart={2}
             onChange={onChangeData}
-            showPrintMargin
+            showPrintMargin={false}
             showGutter
             highlightActiveLine={false}
             value={data}

--- a/app/components/TabList/TabList.tsx
+++ b/app/components/TabList/TabList.tsx
@@ -19,6 +19,13 @@ export interface TabData {
 }
 
 export function TabList({ tabs, activeKey, onChange, onDelete, onEditorRequestChange }: TabListProps) {
+  const tabsWithMatchingKey =
+    tabs.filter(tab => tab.tabKey === activeKey);
+
+  const tabActiveKey = tabsWithMatchingKey.length === 0
+    ? [...tabs.map(tab => tab.tabKey)].pop()
+    : [...tabsWithMatchingKey.map(tab => tab.tabKey)].pop();
+
   return (
     <Tabs
       onEdit={(targetKey, action) => {
@@ -29,7 +36,7 @@ export function TabList({ tabs, activeKey, onChange, onDelete, onEditorRequestCh
       onChange={onChange}
       tabBarStyle={styles.tabBarStyle}
       style={styles.tabList}
-      activeKey={activeKey || "0"}
+      activeKey={tabActiveKey || "0"}
       hideAdd
       type="editable-card"
     >

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
   "dependencies": {
     "@grpc/proto-loader": "^0.3.0",
     "antd": "^3.10.8",
-    "bloomrpc-mock": "^0.2.0",
+    "bloomrpc-mock": "^0.2.2",
     "electron-debug": "^1.1.0",
     "electron-store": "^2.0.0",
     "grpc": "^1.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -934,10 +934,10 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bloomrpc-mock@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/bloomrpc-mock/-/bloomrpc-mock-0.2.0.tgz#49625c0fb95d9872cdb3868f745380cd9f4fa9df"
-  integrity sha512-6k2xhwkPBJtmdbnC2YUHrfpkDV0rQ+lhmvL3ROg4MyiIN0Ho/t4oZ2wSMp0f13UDHS2MyF2ov0gs0YbWIk9Svg==
+bloomrpc-mock@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/bloomrpc-mock/-/bloomrpc-mock-0.2.2.tgz#8eff61ae73aa1969b6c33fab53bd497b46c2a605"
+  integrity sha512-WF3r6q11biTLcxfZHjG1tECe6OA7AfKtsUkCQfPqHoUNLM27k3PdoJTcomJZ95wX5wSMzfKMB/FCwTQ6dWwObg==
   dependencies:
     "@grpc/proto-loader" "^0.3.0"
     "@oclif/command" "^1"
@@ -947,6 +947,7 @@ bloomrpc-mock@^0.2.0:
     colors "^1.3.2"
     google-protobuf "^3.6.1"
     grpc "^1.16.1"
+    lodash "^4.17.11"
     protobufjs "^6.8.8"
     tslib "^1"
     uuid "^3.3.2"


### PR DESCRIPTION
This PR fixes #12. 

It also bring some general improvents to the editor such as:

- Updated bloomrpc-mock which fixed the parsing issue, the editor now supports `nested` namespaces and `map` datatype.
- Persistent Tab guard - always show a tab if persistent tab name is not found
- Close GRPC client connection when the calls ends 
- Small design glitch fixed