### PR TITLE
google.rpc.status support + fix uint parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ We are welcome to any kind of feedback and contributions.
 
 Run this 2 commands in two different terminals
 ```
-npm run server-hot
+npm run hot-server
 npm run start-hot
 ```
 

--- a/app/behaviour/importProtos.ts
+++ b/app/behaviour/importProtos.ts
@@ -4,6 +4,10 @@ import * as path from "path";
 import { ProtoFile, ProtoService } from './protobuf';
 import { Service } from 'protobufjs';
 
+const commonProtosPath = [
+  path.join(process.cwd(), "node_modules/bloomrpc-mock/common"),
+];
+
 export type OnProtoUpload = (protoFiles: ProtoFile[], err?: Error) => void
 
 /**
@@ -33,7 +37,12 @@ export function importProtos(onProtoUploaded: OnProtoUpload, importPaths?: strin
  */
 export async function loadProtos(filePaths: string[], importPaths?: string[], onProtoUploaded?: OnProtoUpload): Promise<ProtoFile[]> {
   try {
-    const protos = await Promise.all(filePaths.map((fileName) => fromFileName(fileName, importPaths)));
+    const protos = await Promise.all(filePaths.map((fileName) =>
+      fromFileName(fileName, [
+        ...(importPaths ? importPaths : []),
+        ...commonProtosPath,
+      ])
+    ));
 
     const protoList = protos.reduce((list: ProtoFile[], proto: Proto) => {
 

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
   },
   "dependencies": {
     "antd": "^3.10.8",
-    "bloomrpc-mock": "^0.2.4-alpha-1",
+    "bloomrpc-mock": "^0.2.5-alpha-2",
     "electron-debug": "^1.1.0",
     "electron-store": "^2.0.0",
     "grpc": "^1.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -934,10 +934,10 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bloomrpc-mock@^0.2.4-alpha-1:
-  version "0.2.4-alpha-1"
-  resolved "https://registry.yarnpkg.com/bloomrpc-mock/-/bloomrpc-mock-0.2.4-alpha-1.tgz#1835c60a6af6be0d7777a9e13fb73e1b0507dba5"
-  integrity sha512-GSaahr9C4Wf79GmpDVvEm57M+RX7J39gJbw/S1uMtLfcFJded62x6ddq7XsUodCdtUDtFBddWo++OfgUYbCCEw==
+bloomrpc-mock@^0.2.5-alpha-2:
+  version "0.2.5-alpha-2"
+  resolved "https://registry.yarnpkg.com/bloomrpc-mock/-/bloomrpc-mock-0.2.5-alpha-2.tgz#b1db68426d3445e5e4ec5c052e1bce6f374e08e4"
+  integrity sha512-oNftUw70Jiql0mDWQoSJG2CYooC40gA9TmDtTs53Be0WjIgNY24VBnHjdOIL8u97lRj9rGGtQEbBlOnciLBQvQ==
   dependencies:
     "@grpc/proto-loader" "^0.3.0"
     "@oclif/command" "^1"


### PR DESCRIPTION
This PR introduces 

- `google.rpc.Status` as a default supported type, fixes #30 
- `uint` data types parsing fixes #32 
