### PR TITLE
[WIP] Load protobuf definition from Url

### DIFF
--- a/app/behaviour/importProtos.ts
+++ b/app/behaviour/importProtos.ts
@@ -3,6 +3,7 @@ import { fromFileName, mockRequestMethods, Proto, walkServices } from 'bloomrpc-
 import * as path from "path";
 import { ProtoFile, ProtoService } from './protobuf';
 import { Service } from 'protobufjs';
+import {getProtoUrls} from "../storage";
 
 const commonProtosPath = [
   path.join(process.cwd(), "node_modules/bloomrpc-mock/common"),
@@ -15,7 +16,7 @@ export type OnProtoUpload = (protoFiles: ProtoFile[], err?: Error) => void
  * @param onProtoUploaded
  * @param importPaths
  */
-export function importProtos(onProtoUploaded: OnProtoUpload, importPaths?: string[]) {
+export function importProtoFiles(onProtoUploaded: OnProtoUpload, importPaths?: string[]) {
   remote.dialog.showOpenDialog({
     properties: ['openFile', 'multiSelections'],
     filters: [
@@ -27,6 +28,16 @@ export function importProtos(onProtoUploaded: OnProtoUpload, importPaths?: strin
     }
     await loadProtos(filePaths, importPaths, onProtoUploaded);
   });
+}
+
+/**
+ * Upload proto from url
+ * @param onProtoUploaded
+ * @param importPaths
+ */
+export function importProtoUrl(onProtoUploaded: OnProtoUpload, importPaths?: string[]) {
+  const urls = getProtoUrls();
+  console.log("Importation: "+urls)
 }
 
 /**

--- a/app/components/BloomRPC.tsx
+++ b/app/components/BloomRPC.tsx
@@ -14,6 +14,7 @@ import {
   storeProtos,
   storeRequestInfo,
   storeTabs,
+  getProtoUrls,
 } from '../storage';
 
 export interface EditorTabs {
@@ -118,6 +119,8 @@ async function hydrateEditor(setProtos: React.Dispatch<ProtoFile[]>, setEditorTa
   const hydration = [];
   const savedProtos = getProtos();
   const importPaths = getImportPaths();
+  const protoUrls = getProtoUrls();
+  console.log("Hydrate URLs: "+protoUrls);
 
   if (savedProtos) {
     hydration.push(
@@ -150,7 +153,8 @@ async function loadTabs(editorTabs: EditorTabsStorage): Promise<EditorTabs> {
   };
 
   const importPaths = getImportPaths();
-
+  const protoUrls = getProtoUrls();
+  console.log("URLs: "+protoUrls);
   const protos = await loadProtos(editorTabs.tabs.map((tab) => {
     return tab.protoPath;
   }), importPaths);

--- a/app/components/Sidebar/PathResolution.tsx
+++ b/app/components/Sidebar/PathResolution.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Icon, Input, Table, Tooltip } from "antd";
 import { useState } from "react";
 import { importResolvePath } from "../../behaviour";
-import { storeImportPaths } from "../../storage";
+import { storeImportPaths } from "../../storage/importPaths";
 
 interface PathResolutionProps {
   onImportsChange?: (paths: string[]) => void

--- a/app/components/Sidebar/Sidebar.tsx
+++ b/app/components/Sidebar/Sidebar.tsx
@@ -2,9 +2,10 @@ import * as React from 'react';
 import { useEffect, useState } from "react";
 import { Button, Icon, Modal, Tooltip, Tree } from 'antd';
 import { Badge } from '../Badge/Badge';
-import { OnProtoUpload, ProtoFile, ProtoService, importProtos } from '../../behaviour';
+import {OnProtoUpload, ProtoFile, ProtoService, importProtoFiles, importProtoUrl} from '../../behaviour';
 import { PathResolution } from "./PathResolution";
-import { getImportPaths } from "../../storage";
+import { getImportPaths, getProtoUrls } from "../../storage";
+import { UrlResolution } from "./UrlResolution";
 
 interface SidebarProps {
   protos: ProtoFile[]
@@ -18,26 +19,37 @@ export function Sidebar({ protos, onMethodSelected, onProtoUpload, onDeleteAll, 
 
   const [importPaths, setImportPaths] = useState<string[]>([""]);
   const [importPathVisible, setImportPathsVisible] = useState(false);
+  const [loadProtoUrlVisible, setLoadProtoUrlVisible] = useState(false);
+  const [protoUrls, setProtoUrls] = useState<string[]>([""]);
 
   useEffect(() => {
     setImportPaths(getImportPaths());
+    setProtoUrls(getProtoUrls());
   }, []);
 
   return (
     <>
       <div style={styles.sidebarTitleContainer}>
         <h3 style={styles.sidebarTitle}>Protos</h3>
-
-        <Tooltip placement="bottom" title="Import protos">
-          <Icon
-            onClick={() => {
-              importProtos(onProtoUpload, importPaths)
-            }}
-            type="plus-circle"
-            theme="filled"
-            style={styles.icon}
-          />
-        </Tooltip>
+        <div style={styles.sidebarActionContainer}>
+          <Tooltip placement="bottom" title="Import protos from file">
+            <Icon
+              onClick={() => {
+                importProtoFiles(onProtoUpload, importPaths)
+              }}
+              type="plus-circle"
+              theme="filled"
+              style={styles.icon}
+            />
+          </Tooltip>
+          <Tooltip placement="bottom" title="Import protos from URL">
+            <Icon
+                onClick={() => setLoadProtoUrlVisible(true)}
+                type="global"
+                style={styles.icon}
+            />
+          </Tooltip>
+        </div>
       </div>
       <div style={styles.optionsContainer}>
         <div style={{width: "50%"}}>
@@ -76,6 +88,31 @@ export function Sidebar({ protos, onMethodSelected, onProtoUpload, onDeleteAll, 
             <PathResolution
                 onImportsChange={setImportPaths}
                 importPaths={importPaths}
+            />
+          </Modal>
+
+          <Modal
+              title={(
+                  <div>
+                    <Icon type="global" />
+                    <span style={{marginLeft: 10}}> Import protos from URL </span>
+                  </div>
+              )}
+              visible={loadProtoUrlVisible}
+              onCancel={() => setLoadProtoUrlVisible(false)}
+              onOk={() => setLoadProtoUrlVisible(false)}
+              bodyStyle={{padding: 0}}
+              width={750}
+              footer={[
+                <Button key="back" onClick={() => {
+                  setLoadProtoUrlVisible(false);
+                  importProtoUrl(onProtoUpload, importPaths)
+                }}>Close</Button>
+              ]}
+          >
+            <UrlResolution
+                onProtoUrlsChange={setProtoUrls}
+                protoUrls={protoUrls}
             />
           </Modal>
         </div>
@@ -158,6 +195,10 @@ const styles = {
     paddingLeft: 20,
     borderBottom: "1px solid #eee",
     background: "#001529"
+  },
+  sidebarActionContainer: {
+    display: "flex",
+    justifyContent: "space-between",
   },
   sidebarTitle: {
     color: "#fff",

--- a/app/components/Sidebar/UrlResolution.tsx
+++ b/app/components/Sidebar/UrlResolution.tsx
@@ -1,0 +1,110 @@
+import * as React from 'react';
+import {Icon, Input, Table, Tooltip} from "antd";
+import {useState} from "react";
+import {storeProtoUrls} from "../../storage";
+
+interface UrlResolutionProps {
+    onProtoUrlsChange?: (urls: string[]) => void
+    protoUrls: string[]
+}
+
+interface TableUrl {
+    value: string
+}
+
+export function UrlResolution({protoUrls, onProtoUrlsChange}: UrlResolutionProps) {
+    const [urlValue, setUrlStateValue] = useState("");
+    const tableUrls = protoUrls.map(protoUrl => ({
+        value: protoUrl,
+    }));
+
+    return (
+        <div>
+            <Table
+                dataSource={tableUrls}
+                pagination={false}
+                rowKey={(url) => url.value || "addPath"}
+            >
+                <Table.Column
+                    title="URLs"
+                    width={"90%"}
+                    key={"urlColumn"}
+                    render={(text, record: TableUrl) => {
+                        return (
+                            <>
+                                {!record.value ? (
+                                    <Input
+                                        value={urlValue}
+                                        placeholder={"Absolute protofile url"}
+                                        autoFocus={urlValue === ""}
+                                        onChange={(e) => {
+                                            setUrlStateValue(e.target.value);
+                                        }}
+                                    />
+                                ) : (
+                                    <span>{record.value}</span>
+                                )}
+                            </>
+                        );
+                    }}
+                />
+
+                <Table.Column
+                    title=""
+                    key={"actionColumn"}
+                    render={(text, url: TableUrl) => (
+                        <>
+                            {url.value ? (
+                                <Tooltip placement="top" title="Remove">
+                                    <Icon
+                                        type="close"
+                                        style={{fontSize: 16, cursor: "pointer", marginTop: 5}}
+                                        onClick={() => removeProtoUrl(url.value, protoUrls, onProtoUrlsChange)}
+                                    />
+                                </Tooltip>
+                            ) : (
+                                <Tooltip placement="top" title="Save">
+                                    <Icon
+                                        style={{color: '#28d440', fontSize: 18, cursor: "pointer", marginTop: 5}}
+                                        type="plus"
+                                        onClick={() => {
+                                            const urlAdded = addProtoUrl(urlValue, protoUrls, onProtoUrlsChange);
+                                            if (urlAdded) {
+                                                setUrlStateValue("");
+                                            }
+                                        }}
+                                    />
+                                </Tooltip>
+                            )}
+                        </>
+                    )}
+                />
+            </Table>
+        </div>
+    );
+}
+
+function addProtoUrl(
+    url: string,
+    protoUrls: string[],
+    setProtoUrls?: (url: string[]) => void,
+): boolean {
+    if (url !== "" && protoUrls.indexOf(url) === -1) {
+        const urls = [...protoUrls, url];
+        setProtoUrls && setProtoUrls(urls);
+        storeProtoUrls(urls);
+        return true;
+    }
+
+    return false;
+}
+
+function removeProtoUrl(
+    url: string,
+    protoUrls: string[],
+    setProtoUrls?: (urls: string[]) => void,
+) {
+    const newUrls = protoUrls.filter(currentUrl => currentUrl !== url);
+    setProtoUrls && setProtoUrls(newUrls);
+    storeProtoUrls(newUrls);
+}

--- a/app/storage/importUrls.ts
+++ b/app/storage/importUrls.ts
@@ -1,0 +1,22 @@
+// @ts-ignore
+import * as Store from "electron-store";
+
+
+const ProtoUrlsStore = new Store({
+  name: "protoUrls",
+});
+const PROTO_URL_KEYS = {
+  PROTO_URL_PATH: "urls"
+};
+
+export function storeProtoUrls(urls: string[]) {
+  ProtoUrlsStore.set(PROTO_URL_KEYS.PROTO_URL_PATH, urls);
+}
+
+export function getProtoUrls(): string[] {
+  return ProtoUrlsStore.get(PROTO_URL_KEYS.PROTO_URL_PATH, [""]);
+}
+
+export function clearProtoUrls() {
+  return ProtoUrlsStore.clear();
+}

--- a/app/storage/index.ts
+++ b/app/storage/index.ts
@@ -5,6 +5,7 @@ import {clearTLS} from './tls';
 
 export * from './editor';
 export * from './importPaths';
+export * from './importUrls';
 export * from './tls';
 
 

--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "antd": "^3.10.8",
     "bloomrpc-mock": "^0.2.5-alpha-2",
     "electron-debug": "^1.1.0",
+    "electron-dl": "^1.13.0",
     "electron-store": "^2.0.0",
     "grpc": "^1.16.1",
     "lodash.get": "^4.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -937,7 +937,6 @@ block-stream@*:
 bloomrpc-mock@^0.2.5-alpha-2:
   version "0.2.5-alpha-2"
   resolved "https://registry.yarnpkg.com/bloomrpc-mock/-/bloomrpc-mock-0.2.5-alpha-2.tgz#b1db68426d3445e5e4ec5c052e1bce6f374e08e4"
-  integrity sha512-oNftUw70Jiql0mDWQoSJG2CYooC40gA9TmDtTs53Be0WjIgNY24VBnHjdOIL8u97lRj9rGGtQEbBlOnciLBQvQ==
   dependencies:
     "@grpc/proto-loader" "^0.3.0"
     "@oclif/command" "^1"
@@ -2398,6 +2397,14 @@ electron-devtools-installer@^2.0.1:
     rimraf "^2.5.2"
     semver "^5.3.0"
 
+electron-dl@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/electron-dl/-/electron-dl-1.13.0.tgz#410981363fcee6909860acfd2b376f31ce0faa59"
+  dependencies:
+    ext-name "^5.0.0"
+    pupa "^1.0.0"
+    unused-filename "^1.0.0"
+
 electron-download-tf@4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/electron-download-tf/-/electron-download-tf-4.3.4.tgz#b03740b2885aa2ad3f8784fae74df427f66d5165"
@@ -2507,7 +2514,6 @@ electron-to-chromium@^1.2.7:
 electron@1.8.8:
   version "1.8.8"
   resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.8.tgz#a90cddb075291f49576993e6f5c8bb4439301cae"
-  integrity sha512-1f9zJehcTTGjrkb06o6ds+gsRq6SYhZJyxOk6zIWjRH8hVy03y/RzUDELzNas71f5vcvXmfGVvyjeEsadDI8tg==
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^3.0.1"
@@ -2875,6 +2881,19 @@ express@^4.14.0:
     type-is "~1.6.16"
     utils-merge "1.0.1"
     vary "~1.1.2"
+
+ext-list@^2.0.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/ext-list/-/ext-list-2.2.2.tgz#0b98e64ed82f5acf0f2931babf69212ef52ddd37"
+  dependencies:
+    mime-db "^1.28.0"
+
+ext-name@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ext-name/-/ext-name-5.0.0.tgz#70781981d183ee15d13993c8822045c506c8f0a6"
+  dependencies:
+    ext-list "^2.0.0"
+    sort-keys-length "^1.0.0"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -3377,7 +3396,6 @@ grpc@^1.16.1:
 grpc@^1.17.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.17.0.tgz#d7971dd39bd4eec90c69a048f7727795ab504876"
-  integrity sha512-5zb5ilwHlsiWfE2Abq/IN5SkHQ2zi4QF/u9Gewcw5DO3y+hGTtzZUiMK52MX3YZHAIRjqxDcO3fx0jLhPjT8Zw==
   dependencies:
     lodash.camelcase "^4.3.0"
     lodash.clone "^4.5.0"
@@ -4695,7 +4713,6 @@ lodash.camelcase@^4.3.0:
 lodash.clone@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
-  integrity sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=
 
 lodash.clonedeep@^4.3.2:
   version "4.5.0"
@@ -4974,6 +4991,10 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
+mime-db@^1.28.0:
+  version "1.38.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.38.0.tgz#1a2aab16da9eb167b49c6e4df2d9c68d63d8e2ad"
+
 mime-db@~1.37.0:
   version "1.37.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.37.0.tgz#0b6a0ce6fdbe9576e25f1f2d2fde8830dc0ad0d8"
@@ -5085,6 +5106,10 @@ mksnapshot@^0.3.0:
     decompress-zip "0.3.0"
     fs-extra "0.26.7"
     request "^2.79.0"
+
+modify-filename@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/modify-filename/-/modify-filename-1.1.0.tgz#9a2dec83806fbb2d975f22beec859ca26b393aa1"
 
 moment@2.x, moment@^2.22.2:
   version "2.22.2"
@@ -6221,6 +6246,10 @@ punycode@^1.2.4, punycode@^1.4.1:
 punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+
+pupa@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pupa/-/pupa-1.0.0.tgz#9a9568a5af7e657b8462a6e9d5328743560ceff6"
 
 q@^1.1.2, q@~1.5.0:
   version "1.5.1"
@@ -7421,6 +7450,12 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
+sort-keys-length@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sort-keys-length/-/sort-keys-length-1.0.1.tgz#9cb6f4f4e9e48155a6aa0671edd336ff1479a188"
+  dependencies:
+    sort-keys "^1.0.0"
+
 sort-keys@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-1.1.2.tgz#441b6d4d346798f1b4e49e8920adfba0e543f9ad"
@@ -8147,6 +8182,13 @@ unset-value@^1.0.0:
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
+
+unused-filename@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unused-filename/-/unused-filename-1.0.0.tgz#d340880f71ae2115ebaa1325bef05cc6684469c6"
+  dependencies:
+    modify-filename "^1.1.0"
+    path-exists "^3.0.0"
 
 unzip-response@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
**Work In Progress**

Here are the different points of this PR to be completed:  
  - [x] Build the UI
  - [x] Store the protobuf urls 
  - [ ] For each url download the protobuf file and load them
  - [ ] When restarting / refreshing bloom, protobuf files are download again instead of using the saved files

Here is a screenshot of the dialog box to set protobuf urls (please note that I have added a new button in the slide bar):
<img width="1009" alt="capture d ecran 2019-03-07 a 01 21 13" src="https://user-images.githubusercontent.com/712517/53923802-d927de80-4079-11e9-9908-6767513d0474.png">

Please let me know if it fits what you have in mind for this feature

Close #45 