### PR TITLE
ensure descriptor.proto is in the import path for custom options

### DIFF
--- a/app/behaviour/importProtos.ts
+++ b/app/behaviour/importProtos.ts
@@ -6,6 +6,7 @@ import { Service } from 'protobufjs';
 
 const commonProtosPath = [
   path.join(process.cwd(), "app/node_modules/bloomrpc-mock/common"),
+  path.join(process.cwd(), "app/node_modules/protobufjs"),
 ];
 
 export type OnProtoUpload = (protoFiles: ProtoFile[], err?: Error) => void

--- a/app/behaviour/importProtos.ts
+++ b/app/behaviour/importProtos.ts
@@ -5,8 +5,8 @@ import { ProtoFile, ProtoService } from './protobuf';
 import { Service } from 'protobufjs';
 
 const commonProtosPath = [
-  path.join(process.cwd(), "app/node_modules/bloomrpc-mock/common"),
-  path.join(process.cwd(), "app/node_modules/protobufjs"),
+  path.join(process.cwd(), "node_modules/bloomrpc-mock/common"),
+  path.join(process.cwd(), "node_modules/protobufjs"),
 ];
 
 export type OnProtoUpload = (protoFiles: ProtoFile[], err?: Error) => void


### PR DESCRIPTION
Fixes https://github.com/uw-labs/bloomrpc/issues/36, which seems to be about custom options rather than extensions as such (as they already work).

See https://github.com/dcodeIO/protobuf.js/blob/d6e3b9e/src/common.js#L34-L41 for why it's required.