### PR TITLE
Remove pacman linux target

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,8 +74,7 @@
     "linux": {
       "target": [
         "deb",
-        "AppImage",
-        "pacman"
+        "AppImage"
       ],
       "category": "Development"
     },


### PR DESCRIPTION
I'm removing the pacman linux target temporarily until we find a way of supporting `Arch` linux within travis.

This will allow the build to succeed again