### PR TITLE
support bin metadata encoding

### DIFF
--- a/app/behaviour/sendRequest.ts
+++ b/app/behaviour/sendRequest.ts
@@ -62,7 +62,29 @@ export class GRPCRequest extends EventEmitter {
     // Add metadata
     const md = new Metadata();
     Object.keys(metadata).forEach(key => {
-      md.add(key, metadata[key]);
+      if (key.endsWith("-bin")) {
+        let encoding = "utf8";
+        let value = metadata[key];
+
+        // can prefix the value with any encoding that the buffer supports
+        // example:
+        // binary://binaryvalue
+        // utf8://anyvalue
+        // base64://sombase64value
+        const regexEncoding = /(^.*):\/\/(.*)/g;
+        if (regexEncoding.test(value)) {
+          const groups = new RegExp(regexEncoding).exec(value);
+
+          if (groups) {
+            encoding = groups[1];
+            value = groups[2];
+          }
+        }
+
+        md.add(key, Buffer.from(value, encoding));
+      } else {
+        md.add(key, metadata[key]);
+      }
     });
 
     // Gather method information


### PR DESCRIPTION
This PR Fixes #105 

BloomRPC will now support any `bin` encoded metadata.

You can specify the encoding format with a protocol prefix example:

```
// binary://binaryvalue
// utf8://anyvalue
// base64://sombase64value
```

Supported encoding are:

```
ascii
utf8
utf16le
ucs2 (alias of utf16le)
base64
binary
hex
```

default to `utf8`