### PR TITLE
feat: response data support display plain buffer string

### DIFF
--- a/app/behaviour/sendRequest.ts
+++ b/app/behaviour/sendRequest.ts
@@ -14,6 +14,10 @@ export interface GRPCRequestInfo {
   tlsCertificate?: Certificate
 }
 
+export interface ResponseData {
+  [k: string]: any;
+}
+
 export interface ResponseMetaInformation {
   responseTime?: number;
   stream?: boolean;

--- a/app/components/Editor/PlayButton.tsx
+++ b/app/components/Editor/PlayButton.tsx
@@ -9,7 +9,7 @@ import {
   addResponseStreamData, setStreamCommitted
 } from './actions';
 import { ControlsStateProps } from './Controls';
-import { GRPCEventType, GRPCRequest, ResponseMetaInformation } from '../../behaviour';
+import { GRPCEventType, GRPCRequest, ResponseData, ResponseMetaInformation } from '../../behaviour';
 
 export const makeRequest = ({ dispatch, state, protoInfo }: ControlsStateProps) => {
   // Do nothing if not set
@@ -57,7 +57,12 @@ export const makeRequest = ({ dispatch, state, protoInfo }: ControlsStateProps) 
     }));
   });
 
-  grpcRequest.on(GRPCEventType.DATA, (data: object, metaInfo: ResponseMetaInformation) => {
+  grpcRequest.on(GRPCEventType.DATA, (data: ResponseData , metaInfo: ResponseMetaInformation) => {
+    Object.keys(data).forEach(key => {
+      if(Buffer.isBuffer(data[key])) {
+        data[key] = JSON.parse(data.content.toString('utf8'));
+      }
+    });
     if (metaInfo.stream && state.interactive) {
       dispatch(addResponseStreamData({
         output: JSON.stringify(data, null, 2),


### PR DESCRIPTION
Sometimes we use buffer as a response, but It is difficult to read a buffer.
So, I made this change to support buffer display as a plain string.