### PR TITLE
feat(styling): add antd dark theme package, remove inline bgs and colors

### DIFF
--- a/app/app.global.less
+++ b/app/app.global.less
@@ -1,12 +1,48 @@
-@import '~antd/dist/antd.css';
+@import '~antd/dist/antd.less';
 
-.root {
-  background: #f0f2f5;
+.editor-container {
+  display: flex;
+  height: 100%;
+}
+.ant-tabs-nav-scroll {
+  border-bottom: none;
+}
+.locked {
+  color: @error-color;
+}
+.unlocked {
+  color: @primary-color;
 }
 
-.ace-tm .ace_gutter {
-  background: #fff !important;
+.ant-tabs-nav .ant-tabs-tab-active{
+  color: @primary-color !important;
 }
+
+.play-icon {
+  background: @primary-color;
+  color: @body-background;
+}
+
+.metadata-container {
+  background: @body-background;
+}
+
+.meatada-panel {
+  background: @body-background;
+}
+
+.import-proto-title-box {
+  color: @primary-color;
+}
+
+.import-proto-icon {
+  color: @icon-color;
+}
+
+.ant-layout-sider {
+  background: @body-background;
+}
+
 
 .ant-tabs-tabpane-inactive {
   height: 0px !important;
@@ -19,10 +55,6 @@
 
 .ant-tabs-bar {
   border-bottom: 0;
-}
-
-.ant-tabs.ant-tabs-card > .ant-tabs-bar .ant-tabs-tab {
-  background: #f1f1f1;
 }
 
 .hide {
@@ -68,15 +100,14 @@
   right: 0px;
 }
 
-.ant-drawer-header {
-  background: #001529;
-  border-radius: 0px;
+// .ant-drawer-header {
+//   background: #001529;
+//   border-radius: 0px;
 
-.ant-drawer-title {
-  color: #fff;
-  font-weight: 700;
-}
-}
+// .ant-drawer-title {
+//   color: #fff;
+//   font-weight: 700;
+// }
 
 .ant-tabs-nav-scroll {
   border-bottom: 1px solid rgb(238, 238, 238);
@@ -105,9 +136,6 @@
   height: 0;
 }
 
-#metadata > .ace_gutter {
-  background: #f0f2f5 !important;
-}
 
 .ant-modal-header {
   background: #001529;

--- a/app/components/BloomRPC.tsx
+++ b/app/components/BloomRPC.tsx
@@ -50,9 +50,9 @@ export function BloomRPC() {
   }, []);
 
   return (
-    <Layout style={styles.layout}>
-      <Layout>
-        <Layout.Sider style={styles.sider} width={250}>
+    <Layout>
+      <Layout style={styles.layout}>
+        <Layout.Sider width={250}>
           <Sidebar
             protos={protos}
             onProtoUpload={handleProtoUpload(setProtos, protos)}
@@ -267,7 +267,6 @@ function handleMethodSelected(editorTabs: EditorTabs, setTabs: React.Dispatch<Ed
     });
   }
 }
-
 const styles = {
   layout: {
     height: "100vh"

--- a/app/components/Editor/Controls.tsx
+++ b/app/components/Editor/Controls.tsx
@@ -69,25 +69,25 @@ const styles = {
     marginTop: 17
   },
   pushData: {
-    background: "#11c9f3",
+    // background: "#11c9f3",
     color: "white",
     padding: "10px",
     paddingLeft: "12px",
     borderRadius: "50% 0 0 50%",
     fontSize: "18px",
     cursor: "pointer",
-    border: "2px solid rgb(238, 238, 238)",
+    // border: "2px solid rgb(238, 238, 238)",
     borderRight: "none"
   },
   commit: {
-    background: "#28d440",
+    // background: "#28d440",
     color: "white",
     padding: "10px",
     paddingLeft: "12px",
     borderRadius: "0 50% 50% 0",
     fontSize: "18px",
     cursor: "pointer",
-    border: "2px solid rgb(238, 238, 238)",
+    // border: "2px solid rgb(238, 238, 238)",
     borderLeft: "none",
   }
 };

--- a/app/components/Editor/Editor.tsx
+++ b/app/components/Editor/Editor.tsx
@@ -19,6 +19,7 @@ import { Certificate, GRPCRequest, ProtoInfo } from '../../behaviour';
 import { getMetadata, getUrl, storeUrl } from '../../storage';
 
 import 'brace/theme/textmate';
+import 'brace/theme/monokai';
 import 'brace/mode/json';
 import 'brace/mode/protobuf';
 import { exportResponseToJSONFile } from "../../behaviour/response";
@@ -27,7 +28,6 @@ import { Command } from 'react-ace';
 import { makeRequest } from './PlayButton';
 import { AddressBar } from "./AddressBar";
 import { deleteEnvironment, getEnvironments, saveEnvironment } from "../../storage/environments";
-
 export interface EditorAction {
   [key: string]: any
   type: string
@@ -293,7 +293,7 @@ export function Editor({ protoInfo, initialRequest, onRequestChange, onEnvironme
         )}
       </div>
 
-      <div style={styles.editorContainer}>
+      <div className="editor-container">
         <Resizable
             enable={{ right: true }}
             defaultSize={{
@@ -370,10 +370,8 @@ const styles = {
     display: "flex",
     height: "100%",
     borderLeft: "1px solid rgba(0, 21, 41, 0.18)",
-    background: "#fff"
   },
   responseContainer: {
-    background: "white",
     maxWidth: "inherit",
     width: "inherit",
     display: "flex",
@@ -397,7 +395,6 @@ const styles = {
     justifyContent: "space-between",
     border: "1px solid rgba(0, 21, 41, 0.18)",
     borderBottom: "1px solid #eee",
-    background: "#fafafa",
     padding: "15px",
     boxShadow: "2px 0px 4px 0px rgba(0,0,0,0.20)",
   },

--- a/app/components/Editor/Metadata.tsx
+++ b/app/components/Editor/Metadata.tsx
@@ -24,13 +24,12 @@ export function Metadata({ onClickMetadata, onMetadataChange, value }: MetadataP
         onResizeStop={(e, direction, ref, d) => {
           setHeight(height + d.height);
         }}
-        className="meatada-panel"
          style={{
            ...styles.optionContainer,
            ...{bottom: `-38px`, height: `${height}px`},
          }}
     >
-      <div>
+      <div className="metadata-container">
         <div style={styles.optionLabel}>
           <a
             href={"#"}
@@ -49,11 +48,10 @@ export function Metadata({ onClickMetadata, onMetadataChange, value }: MetadataP
         <div>
           <AceEditor
             width={"100%"}
-            style={{ background: "#f5f5f5" }}
             height={`${height + 20}px`}
             mode="json"
             focus={visibile}
-            theme="textmate"
+            theme="monokai"
             fontSize={13}
             name="metadata"
             onChange={(value) => {
@@ -76,7 +74,6 @@ export function Metadata({ onClickMetadata, onMetadataChange, value }: MetadataP
 
 const styles = {
   optionLabel: {
-    background: "#001529",
     padding: "7px 10px",
     marginBottom: "5px"
   },
@@ -85,11 +82,9 @@ const styles = {
     fontWeight: 900,
     fontSize: "13px",
     borderLeft: "1px solid rgba(0, 21, 41, 0.18)",
-    background: "#f5f5f5",
     zIndex: 10,
   },
   optionLink: {
-    color: "#fff",
     textDecoration: "none",
   },
 };

--- a/app/components/Editor/Options.tsx
+++ b/app/components/Editor/Options.tsx
@@ -30,10 +30,11 @@ export function Options({ protoInfo, dispatch, interactiveChecked, onInteractive
           }}>
             <Tooltip placement="bottom" title={tlsSelected ? "Secure Connection" : "Unsecure Connection"}>
               <Icon
+                  className={tlsSelected ? "locked" : "unlocked"}
                   type={tlsSelected ? "lock" : "unlock"}
                   style={{
                     fontSize: 18,
-                    color: tlsSelected ? "#28d440" : "#bdbcbc",
+                    // color: tlsSelected ? "#28d440" : "#bdbcbc",
                   }}
               />
             </Tooltip>
@@ -41,7 +42,7 @@ export function Options({ protoInfo, dispatch, interactiveChecked, onInteractive
               onClick={() => setTlsModalVisible(true)}
               style={styles.tlsButton}
             >
-              <span style={{}}>TLS</span>
+              <span>TLS</span>
             </span>
           </div>
 
@@ -118,7 +119,7 @@ const styles = {
   tlsButton: {
     marginLeft: 10,
     cursor: "pointer",
-    background: "#fafafa",
+    // background: "#fafafa",
     padding: "1px 10px",
     borderRadius: "3px",
     fontWeight: 500,

--- a/app/components/Editor/PlayButton.tsx
+++ b/app/components/Editor/PlayButton.tsx
@@ -98,8 +98,9 @@ export const makeRequest = ({ dispatch, state, protoInfo }: ControlsStateProps) 
 export function PlayButton({ dispatch, state, protoInfo }: ControlsStateProps) {
   return (
     <Icon
+      className="play-icon"
       type={state.loading ? "pause-circle" : "play-circle"}
-      theme="filled" style={{ ...styles.playIcon, ...(state.loading ? { color: "#ea5d5d" } : {}) }}
+      theme="filled" style={{ ...styles.playIcon, ...(state.loading ? {} : {}) }}
       onClick={() => makeRequest({ dispatch, state, protoInfo })}
     />
   )
@@ -108,10 +109,8 @@ export function PlayButton({ dispatch, state, protoInfo }: ControlsStateProps) {
 const styles = {
   playIcon: {
     fontSize: 50,
-    color: "#28d440",
     border: "3px solid rgb(238, 238, 238)",
     borderRadius: "50%",
     cursor: "pointer",
-    background: "#fff",
   },
 };

--- a/app/components/Editor/ProtoFileViewer.tsx
+++ b/app/components/Editor/ProtoFileViewer.tsx
@@ -22,11 +22,11 @@ export function ProtoFileViewer({ protoInfo, visible, onClose }: ProtoFileViewer
       visible={visible}
     >
       <AceEditor
-        style={{ marginTop: "10px", background: "#fff" }}
+        style={{ marginTop: "10px"}}
         width={"100%"}
         height={"calc(100vh - 115px)"}
         mode="protobuf"
-        theme="textmate"
+        theme="monokai"
         name="output"
         fontSize={13}
         showPrintMargin={false}

--- a/app/components/Editor/Request.tsx
+++ b/app/components/Editor/Request.tsx
@@ -22,11 +22,10 @@ export function Request({onChangeData, commands, data, streamData}: RequestProps
       >
         <Tabs.TabPane tab="Editor" key={editorTabKey}>
           <AceEditor
-            style={{ background: "#fff" }}
             width={"100%"}
             height={"calc(100vh - 185px)"}
             mode="json"
-            theme="textmate"
+            theme="monokai"
             name="inputs"
             fontSize={13}
             cursorStart={2}

--- a/app/components/Editor/Viewer.tsx
+++ b/app/components/Editor/Viewer.tsx
@@ -59,11 +59,10 @@ export function Viewer({ output, responseTime, emptyContent }: ResponseProps) {
         <AceEditor
           ref={editorRef}
           className={"response-edit"}
-          style={{ background: "#fff" }}
           width={"100%"}
           height={"calc(100vh - 188px)"}
           mode="json"
-          theme="textmate"
+          theme="monokai"
           name="output"
           fontSize={13}
           showPrintMargin={false}
@@ -100,14 +99,12 @@ export function Viewer({ output, responseTime, emptyContent }: ResponseProps) {
 
 const styles = {
   responseContainer: {
-    background: "white",
     position: "relative" as "relative",
   },
   responseTime: {
     userSelect: "none" as "none",
     fontSize: 11,
     padding: "3px 7px",
-    background: '#f3f6f7',
     position: "absolute" as "absolute",
     top: "5px",
     right: "0px",

--- a/app/components/Sidebar/Sidebar.tsx
+++ b/app/components/Sidebar/Sidebar.tsx
@@ -25,7 +25,7 @@ export function Sidebar({ protos, onMethodSelected, onProtoUpload, onDeleteAll, 
 
   return (
     <>
-      <div style={styles.sidebarTitleContainer}>
+      <div className="import-proto-title-box" style={styles.sidebarTitleContainer}>
         <h3 style={styles.sidebarTitle}>Protos</h3>
 
         <Tooltip placement="bottom" title="Import protos">
@@ -36,13 +36,14 @@ export function Sidebar({ protos, onMethodSelected, onProtoUpload, onDeleteAll, 
             type="plus-circle"
             theme="filled"
             style={styles.icon}
+            className="import-proto-icon"
           />
         </Tooltip>
       </div>
       <div style={styles.optionsContainer}>
         <div style={{width: "50%"}}>
           <Tooltip title="Reload" placement="bottomLeft" align={{offset: [-8, 0]}}>
-            <Button type="ghost" style={{height: 22, paddingRight: 5, paddingLeft: 5}} onClick={onReload}>
+            <Button type="ghost" style={{height: 22, paddingRight: 5, paddingLeft: 5, border: 'none'}} onClick={onReload}>
               <Icon type="reload" style={{cursor: "pointer", color: "#1d93e6"}}/>
             </Button>
           </Tooltip>
@@ -50,7 +51,7 @@ export function Sidebar({ protos, onMethodSelected, onProtoUpload, onDeleteAll, 
           <Tooltip title="Import Paths" placement="bottomLeft" align={{offset: [-8, 0]}}>
             <Button
                 type="ghost"
-                style={{height: 22, paddingRight: 5, paddingLeft: 5, marginLeft: 5}}
+                style={{height: 22, paddingRight: 5, paddingLeft: 5, marginLeft: 5, border: 'none'}}
                 onClick={() => setImportPathsVisible(true)}
             >
               <Icon type="file-search" style={{cursor: "pointer", color: "#1d93e6"}}/>
@@ -83,7 +84,7 @@ export function Sidebar({ protos, onMethodSelected, onProtoUpload, onDeleteAll, 
         <div style={{width: "50%", textAlign: "right"}}>
           <Tooltip title="Delete all" placement="bottomRight" align={{offset: [10, 0]}}>
             <Button type="ghost" style={{height: 22, paddingRight: 5, paddingLeft: 5}} onClick={onDeleteAll}>
-              <Icon type="delete" style={{cursor: "pointer", color: "red" }} />
+              <Icon type="delete" style={{cursor: "pointer", border: 'none' }} />
             </Button>
           </Tooltip>
         </div>
@@ -162,27 +163,21 @@ const styles = {
     paddingTop: 14,
     paddingBottom: 4,
     paddingLeft: 20,
-    borderBottom: "1px solid #eee",
-    background: "#001529"
   },
   sidebarTitle: {
-    color: "#fff",
+    // color: "#fff",
   },
   icon: {
     fontSize: 23,
     marginBottom: 7,
     marginRight: 12,
     marginTop: -2,
-    color: "#28d440",
-    border: "2px solid #f3f6f9",
     borderRadius: "50%",
     cursor: "pointer"
   },
   optionsContainer: {
-    background: "#fafafa",
     padding: "3px 6px",
     display: "flex",
     alignContent: "space-between",
-    borderBottom: "1px solid #e0e0e0",
   }
 };

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { render } from 'react-dom';
 import { AppContainer } from 'react-hot-loader';
-import './app.global.scss';
+import './app.global.less';
 import App from './App';
 
 render(

--- a/package.json
+++ b/package.json
@@ -178,6 +178,8 @@
     "husky": "^1.3.1",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^24.3.0",
+    "less": "^3.11.1",
+    "less-loader": "^5.0.0",
     "mini-css-extract-plugin": "^0.5.0",
     "minimist": "^1.2.0",
     "node-sass": "^4.12.0",
@@ -205,6 +207,7 @@
     "yarn": "^1.13.0"
   },
   "dependencies": {
+    "@ant-design/dark-theme": "^1.0.3",
     "antd": "3.26.7",
     "array-move": "^2.1.0",
     "electron-store": "^2.0.0",

--- a/webpack.config.renderer.dev.js
+++ b/webpack.config.renderer.dev.js
@@ -13,6 +13,7 @@ const merge = require('webpack-merge');
 const { spawn } = require('child_process');
 const baseConfig = require('./webpack.config.base');
 const CheckNodeEnv = require('./internals/scripts/CheckNodeEnv');
+const darkTheme = require('@ant-design/dark-theme').default
 
 CheckNodeEnv('development');
 
@@ -40,6 +41,27 @@ module.exports = merge.smart(baseConfig, {
 
   module: {
     rules: [
+      {
+        test: /\.less$/,
+        use: [
+          {
+            loader: 'style-loader'
+          },
+          {
+            loader: 'css-loader',
+            options: {
+              sourceMap: true
+            }
+          },
+          {
+            loader: 'less-loader',
+            options: {
+              modifyVars: darkTheme,
+              javascriptEnabled: true,
+            },
+          }
+        ]
+      },
       {
         test: /\.global\.css$/,
         use: [


### PR DESCRIPTION
The project uses antd as a ui library + a custom scss + inline styles. That makes it a bit tricky to make dynamic dark mode.
We have a couple of options:

1. Add antd dark theme and remove all scss files background colors and inline colors and adjust a bit from there, but it means dynamic dark mode will be tricky
2. Rewrite the styling and maybe use `styled-components`. That way we can leverage the theme provider and use a dynamic dark mode.

I tried option 1 as option 2 requires more work.
I have little to no design sense, but its enough to start this process.
![dark](https://user-images.githubusercontent.com/17418978/74535792-435e2a00-4f3f-11ea-9624-00e8cd8a7a35.png)
Fixes #94 