### PR TITLE
Improve readme to make brew installation steps clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ You can install the client downloading the installer directly from the [Releases
 ```
 brew cask install bloomrpc
 ```
+The app will get installed and copied to the path `/Applications/BloomRPC.app`
 
 ### Build from source:
 


### PR DESCRIPTION
**Details**
While installing BloomRPC on my machine following README I did not understand where I would be able to start bloomRPC executable from. So I have a small PR to add extra details for that.

