### PR TITLE
Fix duplicate input path

### DIFF
--- a/app/components/Sidebar/PathResolution.tsx
+++ b/app/components/Sidebar/PathResolution.tsx
@@ -45,8 +45,10 @@ export function PathResolution({ importPaths, onImportsChange }: PathResolutionP
                       onSearch={async () => {
                         try {
                           const path = await importResolvePath();
+                          if (path != null){
                           setPathStateValue(path);
                           addImportPath(path, importPaths, onImportsChange);
+                        }
                         } catch (e) {
                           // No file selected.
                         }


### PR DESCRIPTION
Scenario to produce:
Duplicate input path appears when user browse to select folder and press cancel.

![image](https://user-images.githubusercontent.com/40818957/78955094-7d325380-7ade-11ea-8c4e-da3f0b5c14b3.png)
