### PR TITLE
bind command-enter for send & esc for focus editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ and querying your GRPC services.
 <br/>
 
 <p align="center">
-  Install the client, select your protobuf files and start making requests! <br/> 
+  Install the client, select your protobuf files and start making requests! <br/>
   <b>No extra</b> steps or configuration <b>needed</b>.
 </p>
 
@@ -34,6 +34,14 @@ and querying your GRPC services.
 - Persistent Workspace
 - Request Cancellation
 - Much more...
+
+### Shortcuts
+
+<kbd>CTRL</kbd>+<kbd>w</kbd> or <kbd>CMD</kbd>+<kbd>w</kbd>: close tab
+
+<kbd>ESC</kbd>: focos editor
+
+<kbd>CTRL</kbd>+<kbd>Enter</kbd> or <kbd>CMD</kbd>+<kbd>Enter</kbd>: send request
 
 ## Installation
 We support all the major operation systems, **MacOS / Windows / Linux Deb - Arch Linux**

--- a/app/components/Editor/Editor.tsx
+++ b/app/components/Editor/Editor.tsx
@@ -23,8 +23,6 @@ import 'brace/mode/json';
 import 'brace/mode/protobuf';
 import { exportResponseToJSONFile } from "../../behaviour/response";
 import Resizable from "re-resizable";
-import { Command } from 'react-ace';
-import { makeRequest } from './PlayButton';
 import { AddressBar } from "./AddressBar";
 import { deleteEnvironment, getEnvironments, saveEnvironment } from "../../storage/environments";
 
@@ -159,16 +157,6 @@ export function Editor({ protoInfo, initialRequest, onRequestChange, onEnvironme
     metadata: (initialRequest && initialRequest.metadata) || getMetadata() || INITIAL_STATE.metadata,
     environment: (initialRequest && initialRequest.environment),
   }, undefined);
-
-  const commands: Command[] = [
-    {
-      name: 'Request',
-      bindKey: { win: 'Ctrl+Enter', mac: 'Command+Enter' },
-      exec: () => {
-        makeRequest({ protoInfo, state, dispatch });
-      },
-    },
-  ];
 
   useEffect(() => {
     if (protoInfo && !initialRequest) {
@@ -305,7 +293,6 @@ export function Editor({ protoInfo, initialRequest, onRequestChange, onEnvironme
           <Request
             data={state.data}
             streamData={state.requestStreamData}
-            commands={commands}
             onChangeData={(value) => {
               dispatch(setData(value));
               onRequestChange && onRequestChange({

--- a/app/components/Editor/PlayButton.tsx
+++ b/app/components/Editor/PlayButton.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { Icon, notification } from 'antd';
+import * as Mousetrap from 'mousetrap'
+import 'mousetrap/plugins/global-bind/mousetrap-global-bind';
 import {
   setCall,
   setIsLoading,
@@ -96,6 +98,18 @@ export const makeRequest = ({ dispatch, state, protoInfo }: ControlsStateProps) 
 };
 
 export function PlayButton({ dispatch, state, protoInfo }: ControlsStateProps) {
+  React.useEffect(() => {
+    Mousetrap.bindGlobal(['ctrl+enter', 'command+enter'], () => {
+      if (state.loading) {
+        return
+      }
+      makeRequest({ dispatch, state, protoInfo })
+    })
+    return () => {
+      Mousetrap.unbind(['ctrl+enter', 'command+enter'])
+    }
+  }, [])
+
   return (
     <Icon
       type={state.loading ? "pause-circle" : "play-circle"}

--- a/app/components/Editor/PlayButton.tsx
+++ b/app/components/Editor/PlayButton.tsx
@@ -108,7 +108,7 @@ export function PlayButton({ dispatch, state, protoInfo }: ControlsStateProps) {
     return () => {
       Mousetrap.unbind(['ctrl+enter', 'command+enter'])
     }
-  }, [])
+  }, [dispatch, state, protoInfo])
 
   return (
     <Icon

--- a/app/components/Editor/Request.tsx
+++ b/app/components/Editor/Request.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import AceEditor, { Command } from 'react-ace';
+import * as Mousetrap from 'mousetrap'
+import 'mousetrap/plugins/global-bind/mousetrap-global-bind';
 import { Tabs } from 'antd';
 import { Viewer } from './Viewer';
 
@@ -12,6 +14,21 @@ interface RequestProps {
 
 export function Request({onChangeData, commands, data, streamData}: RequestProps) {
   const editorTabKey = `editorTab`;
+
+  // bind esc for focus on the active editor window
+  const aceEditor = React.useRef<AceEditor>(null)
+  React.useEffect(() => {
+    Mousetrap.bindGlobal('esc', () => {
+      const node = aceEditor.current as any
+      if (node && 'editor' in node) {
+        node.editor.focus()
+      }
+    })
+
+    return () => {
+      Mousetrap.unbind('esc')
+    }
+  })
 
   return (
     <>

--- a/app/components/Editor/Request.tsx
+++ b/app/components/Editor/Request.tsx
@@ -39,6 +39,7 @@ export function Request({onChangeData, commands, data, streamData}: RequestProps
       >
         <Tabs.TabPane tab="Editor" key={editorTabKey}>
           <AceEditor
+            ref={aceEditor}
             style={{ background: "#fff" }}
             width={"100%"}
             height={"calc(100vh - 185px)"}

--- a/app/menu.js
+++ b/app/menu.js
@@ -196,13 +196,6 @@ module.exports = class MenuBuilder {
             accelerator: 'Ctrl+O'
           },
           {
-            label: '&Close',
-            accelerator: 'Ctrl+W',
-            click: () => {
-              this.mainWindow.close();
-            }
-          },
-          {
             label: '&Quit',
             accelerator: 'Ctrl+Q',
             click: app.quit,


### PR DESCRIPTION
### Shortcuts

<kbd>CTRL</kbd>+<kbd>w</kbd> or <kbd>CMD</kbd>+<kbd>w</kbd>: close tab

<kbd>ESC</kbd>: focos editor

<kbd>CTRL</kbd>+<kbd>Enter</kbd> or <kbd>CMD</kbd>+<kbd>Enter</kbd>: send request

#117 tried to add <kbd>CTRL</kbd>+<kbd>Enter</kbd> from the editor window, but:

1. the shortcut is very useful even when editor windows is not focused.
2. #117 used an incorrect callback within functional component, in my tests, it always fails
