### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You can install the client downloading the installer directly from the [Releases
 #### For MacOS and Homebrew users:
 
 ```
-brew cask install bloomrpc
+brew install --cask bloomrpc
 ```
 The app will get installed and copied to the path `/Applications/BloomRPC.app`
 


### PR DESCRIPTION
`cask install` is deprecated in favour of `install --cask` in Homebrew versions 2.6.0 and completely removed in 2.7.0.
 Refer https://github.com/Homebrew/discussions/discussions/340