### PR TITLE
Update README.md install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You can install the client downloading the installer directly from the [Releases
 #### For MacOS and Homebrew users:
 
 ```
-brew cask install bloomrpc
+brew install --cask bloomrpc
 ```
 The app will get installed and copied to the path `/Applications/BloomRPC.app`
 


### PR DESCRIPTION
For 
```
➜ brew --version
Homebrew 2.7.5
```

## Before 

<img width="597" alt="Screen Shot 2021-01-25 at 10 06 02 AM" src="https://user-images.githubusercontent.com/892749/105747396-94b7bd00-5ef5-11eb-9f10-b0064d9dd4a9.png">

```
➜ brew cask install bloomrpc

Updating Homebrew...
==> Auto-updated Homebrew!
Updated 1 tap (homebrew/core).
==> Updated Formulae
Updated 1 formula.

Error: Calling brew cask install is disabled! Use brew install [--cask] instead.
```

## After

<img width="679" alt="Screen Shot 2021-01-25 at 10 06 11 AM" src="https://user-images.githubusercontent.com/892749/105747427-9da88e80-5ef5-11eb-84c4-f040260fdacd.png">

```
➜ brew install --cask bloomrpc

Updating Homebrew...
==> Downloading https://github.com/uw-labs/bloomrpc/releases/download/1.5.2/BloomRPC-1.5.2.dmg
==> Downloading from https://github-production-release-asset-2e65be.s3.amazonaws.com/161648540/43c10f80-236f-11eb-9109-fbed46235c2d?X-Am
######################################################################## 100.0%
==> Installing Cask bloomrpc
==> Moving App 'BloomRPC.app' to '/Applications/BloomRPC.app'.
🍺  bloomrpc was successfully installed!
```